### PR TITLE
added generic workflow that handles skipped but required checks

### DIFF
--- a/.github/workflows/generic-skip.yaml
+++ b/.github/workflows/generic-skip.yaml
@@ -1,0 +1,13 @@
+name: Test contracts
+# Handles skipped but required checks
+
+on:
+  pull_request:
+    paths-ignore:
+      - "packages/contracts/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No tests required" '


### PR DESCRIPTION
Sometimes a required status check is skipped on pull requests due to path filtering. 

This PR runs a generic `test` job that bypasses the branch protection rule when no tests are required.

For more information see: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks